### PR TITLE
feature/restrict-similarity-to-category

### DIFF
--- a/tests/jobs/test_relate.py
+++ b/tests/jobs/test_relate.py
@@ -10,8 +10,9 @@ from aggrep.jobs.relate import Relater
 class TestRelate:
     """Relater module tests."""
 
-    def test_get_entity_cache(self):
+    def test_get_entity_cache(self, category):
         """Test fetching the entity cache."""
         relater = Relater()
-        relater.get_entity_cache()
+
+        relater.set_entity_cache(category)
         assert type(relater.entity_cache) == defaultdict


### PR DESCRIPTION
This branch restricts similarity processing to posts in the same category. The intent here is twofold: 
1. preserve similarity context, and
2. reduce the memory footprint so Heroku stops freaking out