### PR TITLE
Revert to ents over noun chunks.

### DIFF
--- a/aggrep/jobs/process.py
+++ b/aggrep/jobs/process.py
@@ -16,6 +16,16 @@ nlp = spacy.load("en_core_web_sm")
 
 
 BATCH_SIZE = 250
+EXCLUDES = [
+    "LANGUAGE",
+    "DATE",
+    "TIME",
+    "PERCENT",
+    "MONEY",
+    "QUANTITY",
+    "ORDINAL",
+    "CARDINAL",
+]
 
 
 def clean(text):
@@ -31,8 +41,11 @@ def extract(text):
     entities = set()
     doc = nlp(text)
 
-    for span in doc.noun_chunks:
+    for span in doc.ents:
         for token in span:
+            if token.ent_type_ in EXCLUDES:
+                continue
+
             if len(token) < 2 or len(token) > 40:
                 continue
 
@@ -119,6 +132,7 @@ class Processor(Job):
             batch = enqueued_posts[start:end]
             new_entities += self.process_batch(batch)
             start = end
+            break
 
         current_app.logger.info("Unlocking processor.")
         self.lock.remove()

--- a/tests/jobs/test_process.py
+++ b/tests/jobs/test_process.py
@@ -27,51 +27,8 @@ class TestProcess:
         """Test entity extraction."""
 
         result = extract(BASE_TEXT)
-        expected = set(
-            [
-                "fascism",
-                "activist",
-                "dozen",
-                "franco",
-                "crowd",
-                "flag",
-                "group",
-                "icon",
-                "salute",
-                "november",
-                "demonstration",
-                "glory",
-                "francoist",
-                "de",
-                "hundred",
-                "spain",
-                "female",
-                "plaza",
-                "death",
-                "sunday",
-                "oriente",
-                "feminist",
-                "topless",
-                "legacy",
-                "francisco",
-                "honor",
-                "arm",
-                "woman",
-                "police",
-                "femen",
-                "anniversary",
-                "half",
-                "chest",
-                "supporter",
-                "dictator",
-                "march",
-                "fascist",
-                "madrid",
-                "demonstrator",
-                "slogan",
-            ]
-        )
-        assert len(result) == len(expected)
+        expected = set(["franco", "de", "francisco", "femen", "oriente", "madrid", "plaza"])
+        assert result == expected
 
     def test_clean(self):
         """Test text cleaning util."""


### PR DESCRIPTION
While noun chunks gave us extra context to the keyword sets, it became really difficult to match.